### PR TITLE
Fix SDK location not found issue in Gradle build

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -116,6 +116,8 @@ esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
+# Set the ANDROID_HOME environment variable to the path of the Android SDK
+export ANDROID_HOME=/path/to/your/sdk
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -69,6 +69,8 @@ goto fail
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
+@rem Set the ANDROID_HOME environment variable to the path of the Android SDK
+set ANDROID_HOME=C:\path\to\your\sdk
 
 @rem Execute Gradle
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,1 @@
+sdk.dir=/path/to/your/sdk


### PR DESCRIPTION
Related to #3

Add SDK location configuration to resolve build failure.

* Create `local.properties` file in the root directory with the line `sdk.dir=/path/to/your/sdk`.
* Modify `gradlew` script to set the ANDROID_HOME environment variable to the path of the Android SDK.
* Modify `gradlew.bat` script to set the ANDROID_HOME environment variable to the path of the Android SDK.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/R00tedbrain/SignalProtocolKeyboard-bwt/issues/3?shareId=aa3bf498-9aa8-4203-b5d5-296dd8395659).