### PR TITLE
Upgrade Android Gradle plugin from version 7.3.1 to 7.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         jcenter()
@@ -10,7 +8,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=8cc27038d5dbd815759851ba53e70cf62e481b87494cc97cfd97982ada5ba634
+distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Related to #5

Upgrade the Android Gradle plugin version from 7.3.1 to 7.4.2.

* **build.gradle**
  - Upgrade the Android Gradle plugin version from 7.3.1 to 7.4.2.

* **gradle/wrapper/gradle-wrapper.properties**
  - Update the `distributionSha256Sum` to `29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/R00tedbrain/SignalProtocolKeyboard-bwt/issues/5?shareId=e4300e78-86bf-43ee-9226-d7c295f8b650).