### PR TITLE
Fix SDK location not found issue

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -117,7 +117,7 @@ esac
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
 # Set the ANDROID_HOME environment variable to the path of the Android SDK
-export ANDROID_HOME=/path/to/your/sdk
+export ANDROID_HOME=/Users/sirh0f/Library/Android/sdk
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -70,7 +70,7 @@ goto fail
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 @rem Set the ANDROID_HOME environment variable to the path of the Android SDK
-set ANDROID_HOME=C:\path\to\your\sdk
+set ANDROID_HOME=C:\Users\YourUsername\AppData\Local\Android\Sdk
 
 @rem Execute Gradle
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*


### PR DESCRIPTION
Related to #7

Set the ANDROID_HOME environment variable to the correct path of the Android SDK.

* **gradlew**
  - Set the ANDROID_HOME environment variable to `/Users/sirh0f/Library/Android/sdk`.

* **gradlew.bat**
  - Set the ANDROID_HOME environment variable to `C:\Users\YourUsername\AppData\Local\Android\Sdk`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/R00tedbrain/SignalProtocolKeyboard-bwt/issues/7?shareId=bd439128-38be-4f8c-87b8-d58cf659488b).